### PR TITLE
Remove MaxMind geoipupdate and related configuration

### DIFF
--- a/docker-compose.yml.example
+++ b/docker-compose.yml.example
@@ -141,7 +141,6 @@ services:
 
       - "./data/parsedmarc/parsedmarc.ini:/etc/parsedmarc.ini:ro"
       - "./data/parsedmarc/logs/:/var/log/parsedmarc/:rw"
-      - "./data/geoipupdate/:/usr/share/GeoIP/:ro"
     command: parsedmarc -c /etc/parsedmarc.ini --debug
     networks:
       - parsedmarc-network


### PR DESCRIPTION
This PR removes the MaxMind geoipupdate integration and all related configuration from the repository.

### What Changed
- Cleaned up Docker configuration and tied to geoipupdate.