### PR TITLE
Add PostgreSQL output backend (psycopg)

### DIFF
--- a/docker/parsedmarc/requirements.txt
+++ b/docker/parsedmarc/requirements.txt
@@ -1,2 +1,2 @@
 parsedmarc==10.2.0
-psycopg[binary]==3.2.9
+psycopg[binary]>=3.1.0

--- a/docker/parsedmarc/requirements.txt
+++ b/docker/parsedmarc/requirements.txt
@@ -1,1 +1,2 @@
 parsedmarc==10.2.0
+postgresql

--- a/docker/parsedmarc/requirements.txt
+++ b/docker/parsedmarc/requirements.txt
@@ -1,2 +1,2 @@
 parsedmarc==10.2.0
-postgresql
+psycopg[binary]==3.2.9


### PR DESCRIPTION
Optional output backend. psycopg ships prebuilt binary wheels via the [binary] extra, but those wheels don't exist for every platform/arch, so PostgreSQL support is opt-in rather than a mandatory dependency.